### PR TITLE
Enforce globals module to be ^8.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "babel-eslint": "^4.1.4",
     "broccoli-lint-eslint": "^1.1.1",
+    "globals": "^8.15.0",
     "js-string-escape": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
That version includes all the globals ember test helpers.

See https://github.com/sindresorhus/globals/pull/68.