### PR TITLE
Disable ember-cli-qunit's lintTree hook.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,11 @@ function testGenerator(relativePath, errors) {
 
 module.exports = {
   name: 'ember-cli-qunit-eslint',
+  
+  // instructs ember-cli-qunit and ember-cli-mocha to
+  // disable their lintTree implementations (which use JSHint)
+  isDefaultJSLinter: true,
+  
   lintTree: function(type, tree) {
     return eslint(tree, { testGenerator: testGenerator });
   }


### PR DESCRIPTION
This prevents running both JSHint and ESLint.

As of ember-cli/ember-cli-qunit#102 ember-cli-qunit's lintTree hook is disabled when this property is present on another addon.