### PR TITLE
Remove explicit globals dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "babel-eslint": "^6.0.0-beta.6",
     "broccoli-lint-eslint": "^2.0.1",
-    "globals": "^8.15.0",
     "js-string-escape": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This is no longer needed. eslint uses a newer major version of globals now: https://github.com/eslint/eslint/blob/master/package.json#L50.